### PR TITLE
[AC97] Remove the need for the bit-rate whitelist

### DIFF
--- a/drivers/wdm/audio/drivers/ac97/rtminiport.cpp
+++ b/drivers/wdm/audio/drivers/ac97/rtminiport.cpp
@@ -706,12 +706,12 @@ NTSTATUS CAC97MiniportWaveRT::BuildDataRangeInformation (void)
     // Check for the render sample rates.
     for (nLoop = 0; nLoop < WAVE_SAMPLERATES_TESTED; nLoop++)
     {
-        ntStatus = AdapterCommon->ProgramSampleRate (AC97REG_FRONT_SAMPLERATE,
+        //ntStatus = AdapterCommon->ProgramSampleRate (AC97REG_FRONT_SAMPLERATE,
                                                      dwWaveSampleRates[nLoop]);
 
         // We support the sample rate?
-        if (NT_SUCCESS (ntStatus))
-        {
+       // if (NT_SUCCESS (ntStatus))
+       // {
             // Add it to the PinDataRange
             PinDataRangesPCMStreamRender[nWavePlaybackEntries].DataRange.FormatSize = sizeof(KSDATARANGE_AUDIO);
             PinDataRangesPCMStreamRender[nWavePlaybackEntries].DataRange.Flags      = 0;
@@ -723,15 +723,16 @@ NTSTATUS CAC97MiniportWaveRT::BuildDataRangeInformation (void)
             PinDataRangesPCMStreamRender[nWavePlaybackEntries].MaximumChannels = nChannels;
             PinDataRangesPCMStreamRender[nWavePlaybackEntries].MinimumBitsPerSample = 16;
             PinDataRangesPCMStreamRender[nWavePlaybackEntries].MaximumBitsPerSample = 16;
-            PinDataRangesPCMStreamRender[nWavePlaybackEntries].MinimumSampleFrequency = dwWaveSampleRates[nLoop];
-            PinDataRangesPCMStreamRender[nWavePlaybackEntries].MaximumSampleFrequency = dwWaveSampleRates[nLoop];
+            PinDataRangesPCMStreamRender[nWavePlaybackEntries].MinimumSampleFrequency = 8000;
+            PinDataRangesPCMStreamRender[nWavePlaybackEntries].MaximumSampleFrequency = 48000;
 
             // Add it to the PinDataRangePointer
             PinDataRangePointersPCMStreamRender[nWavePlaybackEntries] = (PKSDATARANGE)&PinDataRangesPCMStreamRender[nWavePlaybackEntries];
 
             // Increase count
             nWavePlaybackEntries++;
-        }
+        //}
+        break;
     }
 
     // Check for the capture sample rates.

--- a/drivers/wdm/audio/drivers/ac97/wavepciminiport.cpp
+++ b/drivers/wdm/audio/drivers/ac97/wavepciminiport.cpp
@@ -745,12 +745,12 @@ NTSTATUS CMiniportWaveICH::BuildDataRangeInformation (void)
     // Check for the render sample rates.
     for (nLoop = 0; nLoop < WAVE_SAMPLERATES_TESTED; nLoop++)
     {
-        ntStatus = AdapterCommon->ProgramSampleRate (AC97REG_FRONT_SAMPLERATE,
-                                                     dwWaveSampleRates[nLoop]);
+       // ntStatus = AdapterCommon->ProgramSampleRate (AC97REG_FRONT_SAMPLERATE,
+        //                                             dwWaveSampleRates[nLoop]);
 
         // We support the sample rate?
-        if (NT_SUCCESS (ntStatus))
-        {
+       // if (NT_SUCCESS (ntStatus))
+       // {
             // Add it to the PinDataRange
             PinDataRangesPCMStreamRender[nWavePlaybackEntries].DataRange.FormatSize = sizeof(KSDATARANGE_AUDIO);
             PinDataRangesPCMStreamRender[nWavePlaybackEntries].DataRange.Flags      = 0;
@@ -762,15 +762,17 @@ NTSTATUS CMiniportWaveICH::BuildDataRangeInformation (void)
             PinDataRangesPCMStreamRender[nWavePlaybackEntries].MaximumChannels = nChannels;
             PinDataRangesPCMStreamRender[nWavePlaybackEntries].MinimumBitsPerSample = 16;
             PinDataRangesPCMStreamRender[nWavePlaybackEntries].MaximumBitsPerSample = 16;
-            PinDataRangesPCMStreamRender[nWavePlaybackEntries].MinimumSampleFrequency = dwWaveSampleRates[nLoop];
-            PinDataRangesPCMStreamRender[nWavePlaybackEntries].MaximumSampleFrequency = dwWaveSampleRates[nLoop];
+            PinDataRangesPCMStreamRender[nWavePlaybackEntries].MinimumSampleFrequency = 8000;
+            PinDataRangesPCMStreamRender[nWavePlaybackEntries].MaximumSampleFrequency = 48000;
 
             // Add it to the PinDataRangePointer
             PinDataRangePointersPCMStreamRender[nWavePlaybackEntries] = (PKSDATARANGE)&PinDataRangesPCMStreamRender[nWavePlaybackEntries];
 
             // Increase count
             nWavePlaybackEntries++;
-        }
+       // }
+       
+       break;
     }
 
     // Check for the capture sample rates.


### PR DESCRIPTION
## Purpose

Allows a program to play audio at any bit-rate (with the minimum bit-rate set to 8000 and the maximum bit-rate set to 48000).

## Proposed changes

- Disable the ProgramSampleRate code
- Make the minimum and maximum bit-rates be static numbers instead of a value name.

This change was done by @TheDeadFish. 
